### PR TITLE
Fix UUID reading bug, where int() needs to guess the base

### DIFF
--- a/openocd.py
+++ b/openocd.py
@@ -118,7 +118,7 @@ class OpenOcd:
   raw = self.send('return $%s' % self._tcl_variable).split(' ')
 
   order = [int(raw[2 * i]) for i in range(len(raw) // 2)]
-  values = [int(raw[2 * i + 1]) for i in range(len(raw) // 2)]
+  values = [int(raw[2 * i + 1], 0) for i in range(len(raw) // 2)]
 
   # Sort the array because it may not be sorted by the memory address.
   result = [0] * len(values)


### PR DESCRIPTION
The int() functions needs an extra argument to set the base. If we set it to 0, it can guess the base from the 0x prefix.